### PR TITLE
Use abstracted `IFileSystem` everywhere for filesystem access

### DIFF
--- a/server/RdtClient.Service/BackgroundServices/WatchFolderChecker.cs
+++ b/server/RdtClient.Service/BackgroundServices/WatchFolderChecker.cs
@@ -62,7 +62,7 @@ public class WatchFolderChecker(ILogger<WatchFolderChecker> logger, IServiceProv
 
                 foreach (var torrentFile in torrentFiles)
                 {
-                    var fileInfo = new FileInfo(torrentFile);
+                    var fileInfo = fileSystem.FileInfo.New(torrentFile);
 
                     if (fileInfo.Extension != ".magnet" && fileInfo.Extension != ".torrent")
                     {
@@ -138,7 +138,7 @@ public class WatchFolderChecker(ILogger<WatchFolderChecker> logger, IServiceProv
         }
     }
 
-    private static Boolean IsFileLocked(FileInfo file)
+    private static Boolean IsFileLocked(IFileInfo file)
     {
         try
         {

--- a/server/RdtClient.Service/DiConfig.cs
+++ b/server/RdtClient.Service/DiConfig.cs
@@ -23,6 +23,8 @@ public static class DiConfig
 
         services.AddSingleton<IProcessFactory, ProcessFactory>();
         services.AddSingleton<IFileSystem, FileSystem>();
+        services.AddSingleton<IRarArchiveWrapper, RarArchiveWrapper>();
+        services.AddSingleton<IZipArchiveWrapper, ZipArchiveWrapper>();
 
         services.AddScoped<Authentication>();
         services.AddScoped<IDownloads, Downloads>();

--- a/server/RdtClient.Service/Helpers/FileHelper.cs
+++ b/server/RdtClient.Service/Helpers/FileHelper.cs
@@ -1,17 +1,18 @@
-﻿using System.Text;
+﻿using System.IO.Abstractions;
+using System.Text;
 
 namespace RdtClient.Service.Helpers;
 
 public static class FileHelper
 {
-    public static async Task Delete(String path)
+    public static async Task Delete(String path, IFileSystem fileSystem)
     {
         if (String.IsNullOrWhiteSpace(path))
         {
             return;
         }
 
-        if (!File.Exists(path))
+        if (!fileSystem.File.Exists(path))
         {
             return;
         }
@@ -22,7 +23,7 @@ public static class FileHelper
         {
             try
             {
-                File.Delete(path);
+                fileSystem.File.Delete(path);
 
                 break;
             }
@@ -40,14 +41,14 @@ public static class FileHelper
         }
     }
 
-    public static async Task DeleteDirectory(String path)
+    public static async Task DeleteDirectory(String path, IFileSystem fileSystem)
     {
         if (String.IsNullOrWhiteSpace(path))
         {
             return;
         }
 
-        if (!Directory.Exists(path))
+        if (!fileSystem.Directory.Exists(path))
         {
             return;
         }
@@ -58,7 +59,7 @@ public static class FileHelper
         {
             try
             {
-                Directory.Delete(path, true);
+                fileSystem.Directory.Delete(path, true);
 
                 break;
             }
@@ -81,22 +82,23 @@ public static class FileHelper
         return String.Concat(filename.Split(Path.GetInvalidFileNameChars()));
     }
     
-    public static String GetDirectoryContents(String path)
+    public static String GetDirectoryContents(String path, IFileSystem fileSystem)
     {
         var stringBuilder = new StringBuilder();
-        GetDirectoryContents(path, stringBuilder, "");
+        GetDirectoryContents(path, stringBuilder, "", fileSystem);
         return stringBuilder.ToString();
     }
 
-    private static void GetDirectoryContents(String path, StringBuilder stringBuilder, String indent)
+    private static void GetDirectoryContents(String path, StringBuilder stringBuilder, String indent, IFileSystem fileSystem)
     {
-        var directoryInfo = new DirectoryInfo(path);
+        fileSystem ??= new FileSystem();
+        var directoryInfo = fileSystem.DirectoryInfo.New(path);
 
         var directories = directoryInfo.GetDirectories();
         foreach (var directory in directories)
         {
             stringBuilder.AppendLine($"{indent}{directory.Name}");
-            GetDirectoryContents(directory.FullName, stringBuilder, indent + "  ");
+            GetDirectoryContents(directory.FullName, stringBuilder, indent + "  ", fileSystem);
         }
 
         var files = directoryInfo.GetFiles();

--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -68,7 +68,7 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
             {
                 Data.Enums.DownloadClient.Internal => new InternalDownloader(download.Link, filePath),
                 Data.Enums.DownloadClient.Bezzad => new BezzadDownloader(download.Link, filePath),
-                Data.Enums.DownloadClient.Aria2c => new Aria2cDownloader(download.RemoteId, download.Link, filePath, downloadPath, category),
+                Data.Enums.DownloadClient.Aria2c => new Aria2cDownloader(download.RemoteId, download.Link, filePath, downloadPath, category, fileSystem),
                 Data.Enums.DownloadClient.Symlink => new SymlinkDownloader(download.Link, filePath, downloadPath, torrent.ClientKind, fileSystem),
                 Data.Enums.DownloadClient.DownloadStation => await DownloadStationDownloader.Init(download.RemoteId, download.Link, filePath, downloadPath, category),
                 _ => throw new($"Unknown download client {Type}")

--- a/server/RdtClient.Service/Services/DownloadClient.cs
+++ b/server/RdtClient.Service/Services/DownloadClient.cs
@@ -1,4 +1,5 @@
-﻿using RdtClient.Data.Enums;
+﻿using System.IO.Abstractions;
+using RdtClient.Data.Enums;
 using RdtClient.Data.Models.Data;
 using RdtClient.Service.Helpers;
 using RdtClient.Service.Services.Downloaders;
@@ -6,7 +7,7 @@ using RdtClient.Service.Services.TorrentClients;
 
 namespace RdtClient.Service.Services;
 
-public class DownloadClient(Download download, Torrent torrent, String destinationPath, String? category)
+public class DownloadClient(Download download, Torrent torrent, String destinationPath, String? category, IFileSystem fileSystem)
 {
     private static Int64 _totalBytesDownloadedThisSession;
     private static readonly Lock TotalBytesDownloadedLock = new();
@@ -60,7 +61,7 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
 
             if (Type != Data.Enums.DownloadClient.Symlink)
             {
-                await FileHelper.Delete(filePath);
+                await FileHelper.Delete(filePath, fileSystem);
             }
 
             Downloader = Type switch
@@ -68,7 +69,7 @@ public class DownloadClient(Download download, Torrent torrent, String destinati
                 Data.Enums.DownloadClient.Internal => new InternalDownloader(download.Link, filePath),
                 Data.Enums.DownloadClient.Bezzad => new BezzadDownloader(download.Link, filePath),
                 Data.Enums.DownloadClient.Aria2c => new Aria2cDownloader(download.RemoteId, download.Link, filePath, downloadPath, category),
-                Data.Enums.DownloadClient.Symlink => new SymlinkDownloader(download.Link, filePath, downloadPath, torrent.ClientKind),
+                Data.Enums.DownloadClient.Symlink => new SymlinkDownloader(download.Link, filePath, downloadPath, torrent.ClientKind, fileSystem),
                 Data.Enums.DownloadClient.DownloadStation => await DownloadStationDownloader.Init(download.RemoteId, download.Link, filePath, downloadPath, category),
                 _ => throw new($"Unknown download client {Type}")
             };

--- a/server/RdtClient.Service/Services/Downloaders/Aria2cDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/Aria2cDownloader.cs
@@ -1,4 +1,5 @@
-﻿using Aria2NET;
+﻿using System.IO.Abstractions;
+using Aria2NET;
 using Serilog;
 
 namespace RdtClient.Service.Services.Downloaders;
@@ -13,13 +14,14 @@ public class Aria2cDownloader : IDownloader
     private readonly Aria2NetClient _aria2NetClient;
 
     private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
     private readonly String _uri;
     private readonly String _filePath;
     private readonly String _remotePath;
 
     private String? _gid;
 
-    public Aria2cDownloader(String? gid, String uri, String filePath, String downloadPath, String? category)
+    public Aria2cDownloader(String? gid, String uri, String filePath, String downloadPath, String? category, IFileSystem fileSystem)
     {
         _logger = Log.ForContext<Aria2cDownloader>();
         _logger.Debug($"Instantiated new Aria2c Downloader for URI {uri} to filePath {filePath} and downloadPath {downloadPath} and GID {gid}");
@@ -27,6 +29,7 @@ public class Aria2cDownloader : IDownloader
         _gid = gid;
         _uri = uri;
         _filePath = filePath;
+        _fileSystem = fileSystem;
 
         if (!String.IsNullOrWhiteSpace(Settings.Get.DownloadClient.Aria2cDownloadPath))
         {
@@ -219,7 +222,7 @@ public class Aria2cDownloader : IDownloader
                     break;
                 }
 
-                if (File.Exists(_filePath))
+                if (_fileSystem.File.Exists(_filePath))
                 {
                     DownloadComplete?.Invoke(this, new());
                     break;

--- a/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
@@ -1,10 +1,11 @@
-﻿using RdtClient.Data.Enums;
+﻿using System.IO.Abstractions;
+using RdtClient.Data.Enums;
 using RdtClient.Service.Helpers;
 using Serilog;
 
 namespace RdtClient.Service.Services.Downloaders;
 
-public class SymlinkDownloader(String uri, String destinationPath, String path, Provider? clientKind) : IDownloader
+public class SymlinkDownloader(String uri, String destinationPath, String path, Provider? clientKind, IFileSystem fileSystem) : IDownloader
 {
     public event EventHandler<DownloadCompleteEventArgs>? DownloadComplete;
     public event EventHandler<DownloadProgressEventArgs>? DownloadProgress;
@@ -155,7 +156,7 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
 
                 try
                 {
-                    var allFolders = FileHelper.GetDirectoryContents(rcloneMountPath);
+                    var allFolders = FileHelper.GetDirectoryContents(rcloneMountPath, fileSystem);
 
                     _logger.Debug(allFolders);
                 }

--- a/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
+++ b/server/RdtClient.Service/Services/Downloaders/SymlinkDownloader.cs
@@ -22,13 +22,13 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
 
         try
         {
-            var filePath = new FileInfo(path);
+            var filePath =  fileSystem.FileInfo.New(path);
 
             var rcloneMountPath = Settings.Get.DownloadClient.RcloneMountPath.TrimEnd(['\\', '/']);
             var searchSubDirectories = rcloneMountPath.EndsWith('*');
             rcloneMountPath = rcloneMountPath.TrimEnd('*').TrimEnd(['\\', '/']);
 
-            if (!Directory.Exists(rcloneMountPath))
+            if (!fileSystem.Directory.Exists(rcloneMountPath))
             {
                 throw new($"Mount path {rcloneMountPath} does not exist!");
             }
@@ -69,7 +69,7 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
                 
                 // Make sure the file exists before making any assumptions.
                 // If this somehow fails, fallback to the search below.
-                if (File.Exists(potentialFilePath))
+                if (fileSystem.File.Exists(potentialFilePath))
                 {
                     _logger.Debug($"Found file {path} at {potentialFilePath} using direct search");
                     file = potentialFilePath;
@@ -89,7 +89,7 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
                     searchPath
                 };
 
-                var directoryInfo = new DirectoryInfo(searchPath);
+                var directoryInfo = fileSystem.DirectoryInfo.New(searchPath);
 
                 while (directoryInfo.Parent != null)
                 {
@@ -126,7 +126,7 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
 
                     if (file == null && searchSubDirectories)
                     {
-                        var subDirectories = Directory.GetDirectories(rcloneMountPath, "*.*", SearchOption.TopDirectoryOnly);
+                        var subDirectories = fileSystem.Directory.GetDirectories(rcloneMountPath, "*.*", SearchOption.TopDirectoryOnly);
 
                         foreach (var subDirectory in subDirectories)
                         {
@@ -217,7 +217,7 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
 
             _logger.Debug($"Searching {potentialFilePathWithFileName}...");
 
-            if (File.Exists(potentialFilePathWithFileName))
+            if (fileSystem.File.Exists(potentialFilePathWithFileName))
             {
                 return potentialFilePathWithFileName;
             }
@@ -230,9 +230,9 @@ public class SymlinkDownloader(String uri, String destinationPath, String path, 
     {
         try
         {
-            File.CreateSymbolicLink(symlinkPath, sourcePath);
+            fileSystem.File.CreateSymbolicLink(symlinkPath, sourcePath);
 
-            if (File.Exists(symlinkPath)) // Double-check that the link was created
+            if (fileSystem.File.Exists(symlinkPath)) // Double-check that the link was created
             {
                 _logger.Information($"Created symbolic link from {sourcePath} to {symlinkPath}");
 

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -10,10 +10,11 @@ using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Text.Json;
 using System.Web;
+using RdtClient.Service.Wrappers;
 
 namespace RdtClient.Service.Services;
 
-public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Downloads downloads, RemoteService remoteService, IFileSystem fileSystem)
+public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Downloads downloads, RemoteService remoteService, IFileSystem fileSystem, IZipArchiveWrapper zipArchiveWrapper, IRarArchiveWrapper rarArchiveWrapper)
 {
     public static readonly ConcurrentDictionary<Guid, DownloadClient> ActiveDownloadClients = new();
     public static readonly ConcurrentDictionary<Guid, UnpackClient> ActiveUnpackClients = new();
@@ -500,7 +501,7 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
                     Log($"Setting unpack path to {downloadPath}", download, torrent);
 
                     // Start the unpacking process
-                    var unpackClient = new UnpackClient(download, downloadPath, fileSystem);
+                    var unpackClient = new UnpackClient(download, downloadPath, fileSystem, zipArchiveWrapper, rarArchiveWrapper);
 
                     if (TorrentRunner.ActiveUnpackClients.TryAdd(download.DownloadId, unpackClient))
                     {

--- a/server/RdtClient.Service/Services/TorrentRunner.cs
+++ b/server/RdtClient.Service/Services/TorrentRunner.cs
@@ -7,12 +7,13 @@ using RdtClient.Service.Helpers;
 using RdtClient.Service.Services.Downloaders;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.IO.Abstractions;
 using System.Text.Json;
 using System.Web;
 
 namespace RdtClient.Service.Services;
 
-public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Downloads downloads, RemoteService remoteService)
+public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Downloads downloads, RemoteService remoteService, IFileSystem fileSystem)
 {
     public static readonly ConcurrentDictionary<Guid, DownloadClient> ActiveDownloadClients = new();
     public static readonly ConcurrentDictionary<Guid, UnpackClient> ActiveUnpackClients = new();
@@ -394,7 +395,7 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
                     Log($"Setting download path to {downloadPath}", download, torrent);
 
                     // Start the download process
-                    var downloadClient = new DownloadClient(download, torrent, downloadPath, torrent.Category);
+                    var downloadClient = new DownloadClient(download, torrent, downloadPath, torrent.Category, fileSystem);
 
                     if (ActiveDownloadClients.TryAdd(download.DownloadId, downloadClient))
                     {
@@ -499,7 +500,7 @@ public class TorrentRunner(ILogger<TorrentRunner> logger, Torrents torrents, Dow
                     Log($"Setting unpack path to {downloadPath}", download, torrent);
 
                     // Start the unpacking process
-                    var unpackClient = new UnpackClient(download, downloadPath);
+                    var unpackClient = new UnpackClient(download, downloadPath, fileSystem);
 
                     if (TorrentRunner.ActiveUnpackClients.TryAdd(download.DownloadId, unpackClient))
                     {

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -572,7 +572,7 @@ public class Torrents(
         {
             Log($"Deleting {filePath}", download, download.Torrent);
 
-            await FileHelper.Delete(filePath);
+            await FileHelper.Delete(filePath, fileSystem);
         }
 
         Log($"Resetting", download, download.Torrent);

--- a/server/RdtClient.Service/Services/Torrents.cs
+++ b/server/RdtClient.Service/Services/Torrents.cs
@@ -133,19 +133,19 @@ public class Torrents(
         {
             try
             {
-                if (!Directory.Exists(Settings.Get.General.CopyAddedTorrents))
+                if (!fileSystem.Directory.Exists(Settings.Get.General.CopyAddedTorrents))
                 {
-                    Directory.CreateDirectory(Settings.Get.General.CopyAddedTorrents);
+                    fileSystem.Directory.CreateDirectory(Settings.Get.General.CopyAddedTorrents);
                 }
 
                 var copyFileName = Path.Combine(Settings.Get.General.CopyAddedTorrents, $"{FileHelper.RemoveInvalidFileNameChars(magnet.Name!)}.magnet");
 
-                if (File.Exists(copyFileName))
+                if (fileSystem.File.Exists(copyFileName))
                 {
-                    File.Delete(copyFileName);
+                    fileSystem.File.Delete(copyFileName);
                 }
 
-                await File.WriteAllTextAsync(copyFileName, magnetLink);
+                await fileSystem.File.WriteAllTextAsync(copyFileName, magnetLink);
             }
             catch (Exception ex)
             {
@@ -184,19 +184,19 @@ public class Torrents(
         {
             try
             {
-                if (!Directory.Exists(Settings.Get.General.CopyAddedTorrents))
+                if (!fileSystem.Directory.Exists(Settings.Get.General.CopyAddedTorrents))
                 {
-                    Directory.CreateDirectory(Settings.Get.General.CopyAddedTorrents);
+                    fileSystem.Directory.CreateDirectory(Settings.Get.General.CopyAddedTorrents);
                 }
 
                 var copyFileName = Path.Combine(Settings.Get.General.CopyAddedTorrents, $"{FileHelper.RemoveInvalidFileNameChars(monoTorrent.Name)}.torrent");
 
-                if (File.Exists(copyFileName))
+                if (fileSystem.File.Exists(copyFileName))
                 {
-                    File.Delete(copyFileName);
+                    fileSystem.File.Delete(copyFileName);
                 }
 
-                await File.WriteAllBytesAsync(copyFileName, bytes);
+                await fileSystem.File.WriteAllBytesAsync(copyFileName, bytes);
             }
             catch (Exception ex)
             {
@@ -335,7 +335,6 @@ public class Torrents(
 
             Log($"Deleting local files in {downloadPath}", torrent);
 
-            if (Directory.Exists(downloadPath))
             {
                 var retry = 0;
 
@@ -343,7 +342,6 @@ public class Torrents(
                 {
                     try
                     {
-                        Directory.Delete(downloadPath, true);
 
                         break;
                     }

--- a/server/RdtClient.Service/Services/UnpackClient.cs
+++ b/server/RdtClient.Service/Services/UnpackClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.IO.Abstractions;
 using RdtClient.Data.Models.Data;
 using RdtClient.Service.Helpers;
 using SharpCompress.Archives;
@@ -7,7 +8,7 @@ using SharpCompress.Archives.Zip;
 
 namespace RdtClient.Service.Services;
 
-public class UnpackClient(Download download, String destinationPath)
+public class UnpackClient(Download download, String destinationPath, IFileSystem fileSystem)
 {
     public Boolean Finished { get; private set; }
         
@@ -80,7 +81,7 @@ public class UnpackClient(Download download, String destinationPath)
             {
                 Extract(filePath, extractPathTemp, cancellationToken);
 
-                await FileHelper.Delete(filePath);
+                await FileHelper.Delete(filePath, fileSystem);
 
                 var rarFiles = Directory.GetFiles(extractPathTemp, "*.r00", SearchOption.TopDirectoryOnly);
 
@@ -93,14 +94,14 @@ public class UnpackClient(Download download, String destinationPath)
                         Extract(mainRarFile, extractPath, cancellationToken);
                     }
 
-                    await FileHelper.DeleteDirectory(extractPathTemp);
+                    await FileHelper.DeleteDirectory(extractPathTemp, fileSystem);
                 }
             }
             else
             {
                 Extract(filePath, extractPath, cancellationToken);
 
-                await FileHelper.Delete(filePath);
+                await FileHelper.Delete(filePath, fileSystem);
             }
         }
         catch (Exception ex)

--- a/server/RdtClient.Service/Services/UnpackClient.cs
+++ b/server/RdtClient.Service/Services/UnpackClient.cs
@@ -52,7 +52,7 @@ public class UnpackClient(Download download, String destinationPath, IFileSystem
     {
         try
         {
-            if (!File.Exists(filePath))
+            if (!fileSystem.File.Exists(filePath))
             {
                 return;
             }
@@ -60,7 +60,7 @@ public class UnpackClient(Download download, String destinationPath, IFileSystem
             var extractPath = destinationPath;
             String? extractPathTemp = null;
 
-            var archiveEntries = await GetArchiveFiles(filePath);
+            var archiveEntries = await GetArchiveFiles(filePath, fileSystem);
 
             if (!archiveEntries.Any(m => m.StartsWith(_torrent.RdName + @"\")) && !archiveEntries.Any(m => m.StartsWith(_torrent.RdName + "/")))
             {
@@ -71,9 +71,9 @@ public class UnpackClient(Download download, String destinationPath, IFileSystem
             {
                 extractPathTemp = Path.Combine(extractPath, Guid.NewGuid().ToString());
                 
-                if (!Directory.Exists(extractPathTemp))
+                if (!fileSystem.Directory.Exists(extractPathTemp))
                 {
-                    Directory.CreateDirectory(extractPathTemp);
+                    fileSystem.Directory.CreateDirectory(extractPathTemp);
                 }
             }
             
@@ -83,13 +83,13 @@ public class UnpackClient(Download download, String destinationPath, IFileSystem
 
                 await FileHelper.Delete(filePath, fileSystem);
 
-                var rarFiles = Directory.GetFiles(extractPathTemp, "*.r00", SearchOption.TopDirectoryOnly);
+                var rarFiles = fileSystem.Directory.GetFiles(extractPathTemp, "*.r00", SearchOption.TopDirectoryOnly);
 
                 foreach (var rarFile in rarFiles)
                 {
                     var mainRarFile = Path.ChangeExtension(rarFile, ".rar");
 
-                    if (File.Exists(mainRarFile))
+                    if (fileSystem.File.Exists(mainRarFile))
                     {
                         Extract(mainRarFile, extractPath, cancellationToken);
                     }
@@ -114,9 +114,9 @@ public class UnpackClient(Download download, String destinationPath, IFileSystem
         }
     }
 
-    private static async Task<IList<String>> GetArchiveFiles(String filePath)
+    private static async Task<IList<String>> GetArchiveFiles(String filePath, IFileSystem fileSystem)
     {
-        await using Stream stream = File.OpenRead(filePath);
+        await using Stream stream = fileSystem.File.OpenRead(filePath);
 
         var extension = Path.GetExtension(filePath);
 

--- a/server/RdtClient.Service/Wrappers/RarArchiveWrapper.cs
+++ b/server/RdtClient.Service/Wrappers/RarArchiveWrapper.cs
@@ -1,0 +1,25 @@
+using System.IO.Abstractions;
+using SharpCompress.Archives.Rar;
+
+namespace RdtClient.Service.Wrappers;
+
+public interface IRarArchiveWrapper
+{
+    public RarArchive Open(IEnumerable<IFileInfo> fileInfos);
+    public RarArchive Open(Stream stream);
+}
+
+public class RarArchiveWrapper : IRarArchiveWrapper
+{
+    public RarArchive Open(IEnumerable<IFileInfo> fileInfos)
+    {
+        var realFileInfos = fileInfos.Select(f => new FileInfo(f.FullName));
+        
+        return RarArchive.Open(realFileInfos);
+    }
+
+    public RarArchive Open(Stream stream)
+    {
+        return RarArchive.Open(stream);
+    }
+}

--- a/server/RdtClient.Service/Wrappers/ZipArchiveWrapper.cs
+++ b/server/RdtClient.Service/Wrappers/ZipArchiveWrapper.cs
@@ -1,0 +1,25 @@
+using System.IO.Abstractions;
+using SharpCompress.Archives.Zip;
+
+namespace RdtClient.Service.Wrappers;
+
+public interface IZipArchiveWrapper
+{
+    public ZipArchive Open(IEnumerable<IFileInfo> fileInfos);
+    public ZipArchive Open(Stream stream);
+}
+
+public class ZipArchiveWrapper : IZipArchiveWrapper
+{
+    public ZipArchive Open(IEnumerable<IFileInfo> fileInfos)
+    {
+        var realFileInfos = fileInfos.Select(f => new FileInfo(f.FullName));
+        
+        return ZipArchive.Open(realFileInfos);
+    }
+
+    public ZipArchive Open(Stream stream)
+    {
+        return ZipArchive.Open(stream);
+    }
+}

--- a/server/RdtClient.Web/Controllers/SettingsController.cs
+++ b/server/RdtClient.Web/Controllers/SettingsController.cs
@@ -71,7 +71,7 @@ public class SettingsController(Settings settings, Torrents torrents, IFileSyste
 
         await fileSystem.File.WriteAllTextAsync(testFile, "RealDebridClient Test File, you can remove this file.");
             
-        await FileHelper.Delete(testFile);
+        await FileHelper.Delete(testFile, fileSystem);
 
         return Ok();
     }
@@ -84,7 +84,7 @@ public class SettingsController(Settings settings, Torrents torrents, IFileSyste
 
         var testFilePath = Path.Combine(downloadPath, "testDefault.rar");
 
-        await FileHelper.Delete(testFilePath);
+        await FileHelper.Delete(testFilePath, fileSystem);
 
         var download = new Download
         {
@@ -96,7 +96,7 @@ public class SettingsController(Settings settings, Torrents torrents, IFileSyste
             }
         };
 
-        var downloadClient = new DownloadClient(download, download.Torrent, downloadPath, null);
+        var downloadClient = new DownloadClient(download, download.Torrent, downloadPath, null, fileSystem);
 
         await downloadClient.Start();
 
@@ -131,7 +131,7 @@ public class SettingsController(Settings settings, Torrents torrents, IFileSyste
             }
         }
 
-        await FileHelper.Delete(testFilePath);
+        await FileHelper.Delete(testFilePath, fileSystem);
 
         return Ok(downloadClient.Speed);
     }
@@ -144,7 +144,7 @@ public class SettingsController(Settings settings, Torrents torrents, IFileSyste
 
         var testFilePath = Path.Combine(downloadPath, "test.tmp");
 
-        await FileHelper.Delete(testFilePath);
+        await FileHelper.Delete(testFilePath, fileSystem);
 
         const Int32 testFileSize = 64 * 1024 * 1024;
 
@@ -171,7 +171,7 @@ public class SettingsController(Settings settings, Torrents torrents, IFileSyste
             
         fileStream.Close();
 
-        await FileHelper.Delete(testFilePath);
+        await FileHelper.Delete(testFilePath, fileSystem);
         
         return Ok(writeSpeed);
     }

--- a/server/RdtClient.Web/Controllers/SettingsController.cs
+++ b/server/RdtClient.Web/Controllers/SettingsController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.IO.Abstractions;
 using Aria2NET;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -13,7 +14,7 @@ namespace RdtClient.Web.Controllers;
 
 [Authorize(Policy = "AuthSetting")]
 [Route("Api/Settings")]
-public class SettingsController(Settings settings, Torrents torrents) : Controller
+public class SettingsController(Settings settings, Torrents torrents, IFileSystem fileSystem) : Controller
 {
     [HttpGet]
     [Route("")]
@@ -61,14 +62,14 @@ public class SettingsController(Settings settings, Torrents torrents) : Controll
 
         var path = request.Path.TrimEnd('/').TrimEnd('\\');
 
-        if (!Directory.Exists(path))
+        if (!fileSystem.Directory.Exists(path))
         {
             throw new($"Path {path} does not exist");
         }
 
         var testFile = $"{path}/test.txt";
 
-        await System.IO.File.WriteAllTextAsync(testFile, "RealDebridClient Test File, you can remove this file.");
+        await fileSystem.File.WriteAllTextAsync(testFile, "RealDebridClient Test File, you can remove this file.");
             
         await FileHelper.Delete(testFile);
 


### PR DESCRIPTION
PR primarily here to show a diff against my existing work using `System.IO.Abstractions`.

This PR implements using `TestableIO.System.IO.Abstractions` everywhere for filesystem access.

Lets tests be written (or at least makes them easier to write) for all the things I've touched.

Also adds wrapper classes for `SharpCompress.Archives.Zip.ZipArchive#Open` and ``SharpCompress.Archives.Rar.RarArchive#Open` so we can dependency inject them (static methods) and so we can ensure it accepts the abstracted `IFileInfo` rather than `FileInfo`
These might be better off in one class with a n`OpenZip` and an `OpenRar` method.